### PR TITLE
add:Word文档导入插件

### DIFF
--- a/docs/en/guide/plugins.md
+++ b/docs/en/guide/plugins.md
@@ -6,3 +6,4 @@
 - [Markdown](https://github.com/cycleccc/wangEditor-next-plugin-md/blob/main/README-en.md)
 - [Upload attachment](https://github.com/cycleccc/wangEditor-plugin-upload-attachment/blob/main/README-en.md)
 - [Link card](https://github.com/cycleccc/wangEditor-plugin-link-card/blob/main/README-en.md)
+- [Import From Word](https://github.com/yutons3112/wangEditor-next-plugin-import-from-word)

--- a/docs/zh/guide/plugins.md
+++ b/docs/zh/guide/plugins.md
@@ -6,3 +6,4 @@
 - [markdown](https://github.com/cycleccc/wangEditor-next-plugin-md)
 - [上传附件](https://github.com/cycleccc/wangEditor-plugin-upload-attachment)
 - [链接卡片](https://github.com/cycleccc/wangEditor-plugin-link-card)
+- [Word文档导入](https://github.com/yutons3112/wangEditor-next-plugin-import-from-word)


### PR DESCRIPTION
添加从Word文档导入插件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated plugin documentation in English and Chinese guides
	- Removed several plugin links (ctrl+enter insertBeak, Mention, Formula, Markdown, Upload attachment, Link card)
	- Added new "Import From Word" plugin link in both language guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->