### PR TITLE
Update installation.md for change  Vue3 Component Install Name

### DIFF
--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -28,8 +28,8 @@ yarn add @wangeditor-next/editor-for-vue2
 安装 Vue3 组件(可选)
 
 ```shell
-yarn add @wangeditor-next/editor-for-vue@next
-# 或者 npm install @wangeditor-next/editor-for-vue@next --save
+yarn add @wangeditor-next/editor-for-vue
+# 或者 npm install @wangeditor-next/editor-for-vue --save
 ```
 
 ## CDN


### PR DESCRIPTION
Update installation.md for change Vue3 Component Install Name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for the Vue3 component to remove the `@next` tag from the package name, reflecting the latest recommended installation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->