### PR TITLE
fix: typo of index.md

### DIFF
--- a/docs/zh/guide/index.md
+++ b/docs/zh/guide/index.md
@@ -102,7 +102,7 @@ editor.getAllMenuKeys()
 
 PS：同时，wangEditor 有丰富的 [API](./API.md) 和足够的扩展性，允许你[自定义开发](./development.md)菜单、模块、插件等。
 
-### 很方便的应用于 Vue React
+### 很方便地应用于 Vue React
 
 wangEditor 基于 slate 内核开发，但不依赖于 React ，所以它本身是无框架依赖的。
 


### PR DESCRIPTION
use '地' instead of '的'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a grammatical error in a section header to improve language accuracy in the Chinese guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->