### PR TITLE
docs(upload): add upload adapter guide

### DIFF
--- a/docs/en/guide/menu-config.md
+++ b/docs/en/guide/menu-config.md
@@ -281,7 +281,8 @@ editorConfig.MENU_CONF['uploadImage'] = {
 
 ### Server Address
 
-Required.
+Required when you use the built-in uploader.
+If you use `customUpload` or `uploadAdapter`, `server` is not required.
 
 ```ts
 editorConfig.MENU_CONF['uploadImage'] = {
@@ -438,6 +439,58 @@ editorConfig.MENU_CONF['uploadImage'] = {
 }
 ```
 
+#### Upload Adapter
+
+If you want to replace the transport layer but still reuse wangEditor's built-in upload callbacks and insert flow, use `uploadAdapter`.
+
+- `customUpload` means you fully take over upload and insertion
+- `uploadAdapter` means you only replace the uploader implementation, while the editor still reuses the existing progress, success, error, and insert flow
+- If both `customUpload` and `uploadAdapter` are configured, `customUpload` has higher priority
+
+```ts
+editorConfig.MENU_CONF['uploadImage'] = {
+    uploadAdapter({ config, editor }) {
+        const files: File[] = []
+
+        return {
+            addFiles(fileList) {
+                files.push(...fileList.map(item => item.data as File))
+            },
+            async upload() {
+                for (const file of files) {
+                    const fileInfo = {
+                        name: file.name,
+                        type: file.type,
+                        size: file.size,
+                    }
+
+                    try {
+                        const res = await myUpload(file, editor)
+
+                        config.onProgress?.(100)
+                        config.onSuccess(fileInfo, {
+                            errno: 0,
+                            data: {
+                                url: res.url,
+                                alt: file.name,
+                                href: res.url,
+                            },
+                        })
+                    } catch (err) {
+                        config.onError(fileInfo, err, null)
+                    }
+                }
+            },
+        }
+    },
+}
+```
+
+:::tip
+`uploadAdapter` should call `config.onProgress`, `config.onSuccess`, `config.onError`, and related callbacks at the right time.
+If you want to reuse the editor's default insert flow, pass the same response body shape as the built-in uploader to `config.onSuccess`. If your response body is different, combine it with `customInsert`.
+:::
+
 #### Custom Select Images
 
 If you unwanted wangEditor's embedded select function, you can use `customBrowseAndUpload` to implement by yourself.
@@ -542,7 +595,8 @@ editorConfig.MENU_CONF['uploadVideo'] = {
 
 ### Server Address
 
-Required.
+Required when you use the built-in uploader.
+If you use `customUpload` or `uploadAdapter`, `server` is not required.
 
 ```ts
 editorConfig.MENU_CONF['uploadVideo'] = {
@@ -701,6 +755,57 @@ editorConfig.MENU_CONF['uploadVideo'] = {
     }
 }
 ```
+
+#### Upload Adapter
+
+If you want to replace the transport layer but still reuse wangEditor's built-in upload callbacks and insert flow, use `uploadAdapter`.
+
+- `customUpload` means you fully take over upload and insertion
+- `uploadAdapter` means you only replace the uploader implementation, while the editor still reuses the existing progress, success, error, and insert flow
+- If both `customUpload` and `uploadAdapter` are configured, `customUpload` has higher priority
+
+```ts
+editorConfig.MENU_CONF['uploadVideo'] = {
+    uploadAdapter({ config, editor }) {
+        const files: File[] = []
+
+        return {
+            addFiles(fileList) {
+                files.push(...fileList.map(item => item.data as File))
+            },
+            async upload() {
+                for (const file of files) {
+                    const fileInfo = {
+                        name: file.name,
+                        type: file.type,
+                        size: file.size,
+                    }
+
+                    try {
+                        const res = await myUpload(file, editor)
+
+                        config.onProgress?.(100)
+                        config.onSuccess(fileInfo, {
+                            errno: 0,
+                            data: {
+                                url: res.url,
+                                poster: res.poster || "",
+                            },
+                        })
+                    } catch (err) {
+                        config.onError(fileInfo, err, null)
+                    }
+                }
+            },
+        }
+    },
+}
+```
+
+:::tip
+`uploadAdapter` should call `config.onProgress`, `config.onSuccess`, `config.onError`, and related callbacks at the right time.
+If you want to reuse the editor's default insert flow, pass the same response body shape as the built-in uploader to `config.onSuccess`. If your response body is different, combine it with `customInsert`.
+:::
 
 #### Custom Select Videos
 

--- a/docs/zh/guide/menu-config.md
+++ b/docs/zh/guide/menu-config.md
@@ -298,7 +298,8 @@ editorConfig.MENU_CONF['uploadImage'] = {
 
 ### 服务端地址
 
-**必填**，否则上传图片会报错。
+使用内置上传器时 **必填**，否则上传图片会报错。
+如果你使用 `customUpload` 或 `uploadAdapter` ，则不需要配置 `server` 。
 
 ```ts
 editorConfig.MENU_CONF['uploadImage'] = {
@@ -459,6 +460,59 @@ editorConfig.MENU_CONF['uploadImage'] = {
 }
 ```
 
+#### 自定义上传适配器
+
+如果你想替换底层上传实现，但仍然复用 wangEditor 内置的上传回调和插入链路，可以使用 `uploadAdapter` 。
+
+- `customUpload` 表示你完全接管上传和插入
+- `uploadAdapter` 表示你只替换上传器实现，编辑器仍然复用现有的进度、成功、失败、错误和插入流程
+- 如果同时配置了 `customUpload` 和 `uploadAdapter` ，则优先使用 `customUpload`
+
+```ts
+editorConfig.MENU_CONF['uploadImage'] = {
+    uploadAdapter({ config, editor }) {
+        const files: File[] = []
+
+        return {
+            addFiles(fileList) {
+                files.push(...fileList.map(item => item.data as File))
+            },
+            async upload() {
+                for (const file of files) {
+                    const fileInfo = {
+                        name: file.name,
+                        type: file.type,
+                        size: file.size,
+                    }
+
+                    try {
+                        // 例如：上传到 OSS / S3 / 自定义服务
+                        const res = await myUpload(file, editor)
+
+                        config.onProgress?.(100)
+                        config.onSuccess(fileInfo, {
+                            errno: 0,
+                            data: {
+                                url: res.url,
+                                alt: file.name,
+                                href: res.url,
+                            },
+                        })
+                    } catch (err) {
+                        config.onError(fileInfo, err, null)
+                    }
+                }
+            },
+        }
+    },
+}
+```
+
+:::tip
+`uploadAdapter` 需要在合适的时机主动调用 `config.onProgress`、`config.onSuccess`、`config.onError` 等回调。
+如果你想复用编辑器默认插入逻辑，请给 `config.onSuccess` 传入和内置上传一致的 response body；如果你的返回格式不同，可以配合 `customInsert` 一起使用。
+:::
+
 #### 自定义选择图片
 
 如果你不想使用 wangEditor 自带的选择文件功能，例如你有自己的图床，或者图片选择器。<br>
@@ -573,7 +627,8 @@ editorConfig.MENU_CONF['uploadVideo'] = {
 
 ### 服务端地址
 
-**必填**，否则上传视频会报错。
+使用内置上传器时 **必填**，否则上传视频会报错。
+如果你使用 `customUpload` 或 `uploadAdapter` ，则不需要配置 `server` 。
 
 ```ts
 editorConfig.MENU_CONF['uploadVideo'] = {
@@ -735,6 +790,57 @@ editorConfig.MENU_CONF['uploadVideo'] = {
     }
 }
 ```
+
+#### 自定义上传适配器
+
+如果你想替换底层上传实现，但仍然复用 wangEditor 内置的上传回调和插入链路，可以使用 `uploadAdapter` 。
+
+- `customUpload` 表示你完全接管上传和插入
+- `uploadAdapter` 表示你只替换上传器实现，编辑器仍然复用现有的进度、成功、失败、错误和插入流程
+- 如果同时配置了 `customUpload` 和 `uploadAdapter` ，则优先使用 `customUpload`
+
+```ts
+editorConfig.MENU_CONF['uploadVideo'] = {
+    uploadAdapter({ config, editor }) {
+        const files: File[] = []
+
+        return {
+            addFiles(fileList) {
+                files.push(...fileList.map(item => item.data as File))
+            },
+            async upload() {
+                for (const file of files) {
+                    const fileInfo = {
+                        name: file.name,
+                        type: file.type,
+                        size: file.size,
+                    }
+
+                    try {
+                        const res = await myUpload(file, editor)
+
+                        config.onProgress?.(100)
+                        config.onSuccess(fileInfo, {
+                            errno: 0,
+                            data: {
+                                url: res.url,
+                                poster: res.poster || "",
+                            },
+                        })
+                    } catch (err) {
+                        config.onError(fileInfo, err, null)
+                    }
+                }
+            },
+        }
+    },
+}
+```
+
+:::tip
+`uploadAdapter` 需要在合适的时机主动调用 `config.onProgress`、`config.onSuccess`、`config.onError` 等回调。
+如果你想复用编辑器默认插入逻辑，请给 `config.onSuccess` 传入和内置上传一致的 response body；如果你的返回格式不同，可以配合 `customInsert` 一起使用。
+:::
 
 #### 自定义选择视频
 


### PR DESCRIPTION
## Summary

Add documentation for the new `uploadAdapter` upload abstraction.

## What changed

- document `uploadAdapter` for `uploadImage`
- document `uploadAdapter` for `uploadVideo`
- clarify `server` is only required for the built-in uploader path
- document priority: `customUpload` > `uploadAdapter` > built-in uploader
- add examples showing the adapter contract and callback usage

## Notes

- `uploadAdapter` should call `config.onProgress`, `config.onSuccess`, `config.onError`, and related callbacks
- to reuse the default insert flow, pass the same response body shape as the built-in uploader
- if the response body differs, combine `uploadAdapter` with `customInsert`

Related code change:
- wangeditor-next/wangEditor-next#807


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced guidance for upload configuration options with clearer requirements for built-in uploader versus custom solutions
* Added documentation and examples for the upload adapter functionality, including callback timing and response compatibility notes
* Updated in both English and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->