### PR TITLE
docs(csp): add bilingual class style mode guide

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -106,6 +106,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
             items: [
                 { text: 'Toolbar Configuration', link: '/toolbar-config' },
                 { text: 'Editor Configuration', link: '/editor-config' },
+                { text: 'CSP Class Style Mode', link: '/csp-class-mode' },
                 { text: 'Menu Configuration', link: '/menu-config' },
                 { text: 'Editor API', link: '/API' },
             ],

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -106,6 +106,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
             items: [
                 { text: '工具栏配置', link: '/toolbar-config' },
                 { text: '编辑器配置', link: '/editor-config' },
+                { text: 'CSP class 样式模式', link: '/csp-class-mode' },
                 { text: '菜单配置', link: '/menu-config' },
                 { text: '编辑器 API', link: '/API' },
             ],

--- a/docs/en/guide/csp-class-mode.md
+++ b/docs/en/guide/csp-class-mode.md
@@ -1,0 +1,104 @@
+# CSP Class Style Mode
+
+For strict CSP environments (for example, inline `style` is blocked), use `textStyleMode: 'class'` so style output uses `class + data-w-e-*`.
+
+:::tip
+The default mode is still `inline`, so existing projects keep working without changes.
+:::
+
+## Quick Start
+
+```ts
+import { createEditor, IEditorConfig } from '@wangeditor-next/editor'
+
+const editorConfig: Partial<IEditorConfig> = {
+    textStyleMode: 'class',
+    classStylePolicy: 'preserve-data',
+    styleClassTokens: {
+        color: ['rgb(1, 2, 3)'],
+    },
+    onClassStyleUnsupported(payload) {
+        console.warn('[class-style-unsupported]', payload)
+    },
+}
+
+const editor = createEditor({
+    selector: '#editor-container',
+    config: editorConfig,
+    html: '<p><br></p>',
+})
+```
+
+Make sure the editor stylesheet is loaded (it includes built-in token class styles):
+
+```html
+<link
+  href="https://unpkg.com/@wangeditor-next/editor@latest/dist/css/style.css"
+  rel="stylesheet"
+>
+```
+
+## Config Fields
+
+### `textStyleMode`
+
+- `inline` (default): style output goes to `style`.
+- `class`: style output goes to `class + data-w-e-*`.
+
+### `classStylePolicy`
+
+Only works when `textStyleMode: 'class'`.
+
+- `preserve-data` (default): keep `data-w-e-*` only, no class/inline (round-trip safe, may not render visual style).
+- `fallback-inline`: keep `data-w-e-*` and fallback to inline style (render-first behavior).
+- `strict`: throw on unsupported tokens (no silent degradation).
+
+### `styleClassTokens`
+
+- Registers additional accepted tokens.
+- It only registers tokens and does not inject your custom CSS automatically.
+
+### `onClassStyleUnsupported`
+
+Called when an unsupported token is detected. Useful for logging and monitoring.
+
+Payload fields:
+
+- `type`
+- `value`
+- `scene` (`render` or `toHtml`)
+- `fallback` (`preserve-data` / `inline` / `throw`)
+- `message`
+
+## Supported Text Style Types
+
+- `color`
+- `bgColor`
+- `fontSize`
+- `fontFamily`
+- `textAlign`
+- `lineHeight`
+- `indent`
+
+## CSS for Custom Tokens
+
+For custom tokens, prefer rules based on `data-w-e-*` instead of hash class names:
+
+```css
+[data-w-e-color="rgb(1, 2, 3)"] { color: rgb(1, 2, 3); }
+[data-w-e-font-size="20px"] { font-size: 20px; }
+[data-w-e-line-height="2"] { line-height: 2; }
+```
+
+## Module Behavior
+
+- `basic-modules`: text styles follow policy output (class/data/inline).
+- `list-module`: list marker color class is `w-e-list-color-*` and keeps `data-w-e-color`.
+- `table-module`: `border-style` in class mode follows policy (single-value class support, complex values degrade by policy).
+- `video-module`, `image`, `plugin-float-image`: alignment and size prefer class/data output.
+
+## Migration Suggestion
+
+1. Start in test env with `textStyleMode: 'class'` + `classStylePolicy: 'preserve-data'`.
+2. Observe `onClassStyleUnsupported` logs, then add `styleClassTokens` and matching CSS.
+3. Move to `fallback-inline` or `strict` based on your production policy.

--- a/docs/en/guide/editor-config.md
+++ b/docs/en/guide/editor-config.md
@@ -57,6 +57,58 @@ When you need to set `false`?
 - Want a Google doc style, see [Demo](https://wangeditor-next.github.io/demo/like-qq-doc.html?lang=en)
 :::
 
+## textStyleMode
+
+Configure text/paragraph style export mode.
+
+```ts
+editorConfig.textStyleMode = 'class' // 'inline' | 'class'
+```
+
+- `inline` (default): output inline `style`
+- `class`: output `class + data-w-e-*` for strict CSP scenarios
+
+For full usage and migration guidance, see [CSP Class Style Mode](./csp-class-mode.md).
+
+## classStylePolicy
+
+When `textStyleMode = 'class'`, configure how unsupported tokens are handled.
+
+```ts
+editorConfig.classStylePolicy = 'preserve-data'
+// 'preserve-data' | 'fallback-inline' | 'strict'
+```
+
+- `preserve-data` (default): keep `data-w-e-*`
+- `fallback-inline`: fallback to inline style
+- `strict`: throw error directly
+
+## styleClassTokens
+
+Register extra accepted tokens for class mode.
+
+```ts
+editorConfig.styleClassTokens = {
+    color: ['rgb(1, 2, 3)'],
+    fontSize: ['20px'],
+}
+```
+
+:::tip
+`styleClassTokens` only registers tokens, it does not inject your custom CSS.
+:::
+
+## onClassStyleUnsupported
+
+Callback for unsupported tokens in class mode.
+
+```ts
+editorConfig.onClassStyleUnsupported = payload => {
+    // payload: { type, value, scene, fallback, message }
+    console.warn(payload)
+}
+```
+
 ## maxLength onMaxLength
 
 See [demo](https://wangeditor-next.github.io/demo/max-length.html?lang=en).

--- a/docs/zh/guide/csp-class-mode.md
+++ b/docs/zh/guide/csp-class-mode.md
@@ -1,0 +1,104 @@
+# CSP class 样式模式
+
+在严格 CSP（例如禁止内联 `style`）场景下，可使用 `textStyleMode: 'class'` 让样式以 `class + data-w-e-*` 输出。
+
+:::tip
+默认模式仍是 `inline`，老项目无需改动即可继续使用。
+:::
+
+## 快速开始
+
+```ts
+import { createEditor, IEditorConfig } from '@wangeditor-next/editor'
+
+const editorConfig: Partial<IEditorConfig> = {
+    textStyleMode: 'class',
+    classStylePolicy: 'preserve-data',
+    styleClassTokens: {
+        color: ['rgb(1, 2, 3)'],
+    },
+    onClassStyleUnsupported(payload) {
+        console.warn('[class-style-unsupported]', payload)
+    },
+}
+
+const editor = createEditor({
+    selector: '#editor-container',
+    config: editorConfig,
+    html: '<p><br></p>',
+})
+```
+
+同时请确保引入编辑器样式文件（内置默认 token 的 class 样式）：
+
+```html
+<link
+  href="https://unpkg.com/@wangeditor-next/editor@latest/dist/css/style.css"
+  rel="stylesheet"
+>
+```
+
+## 配置项说明
+
+### `textStyleMode`
+
+- `inline`（默认）：样式输出到 `style`。
+- `class`：样式输出到 `class + data-w-e-*`。
+
+### `classStylePolicy`
+
+仅在 `textStyleMode: 'class'` 下生效。
+
+- `preserve-data`（默认）：仅保留 `data-w-e-*`，不输出 class/inline（可回读，可能不展示）。
+- `fallback-inline`：保留 `data-w-e-*`，并回退到内联样式（优先展示）。
+- `strict`：遇到未注册 token 直接抛错（避免静默降级）。
+
+### `styleClassTokens`
+
+- 用于注册额外可接受的 token。
+- 仅注册 token，不会自动注入你的业务样式。
+
+### `onClassStyleUnsupported`
+
+当遇到未注册 token 时回调，便于日志与监控。
+
+回调 payload 包含：
+
+- `type`
+- `value`
+- `scene`（`render` 或 `toHtml`）
+- `fallback`（`preserve-data` / `inline` / `throw`）
+- `message`
+
+## 支持的文本样式类型
+
+- `color`
+- `bgColor`
+- `fontSize`
+- `fontFamily`
+- `textAlign`
+- `lineHeight`
+- `indent`
+
+## 自定义 token 的 CSS 约定
+
+推荐优先基于 `data-w-e-*` 写规则，不依赖 hash class 名：
+
+```css
+[data-w-e-color="rgb(1, 2, 3)"] { color: rgb(1, 2, 3); }
+[data-w-e-font-size="20px"] { font-size: 20px; }
+[data-w-e-line-height="2"] { line-height: 2; }
+```
+
+## 模块行为说明
+
+- `basic-modules`：文本样式按策略输出 class/data/inline。
+- `list-module`：列表颜色 class 使用 `w-e-list-color-*`，并保留 `data-w-e-color`。
+- `table-module`：`border-style` 在 class 模式下按策略处理（支持单值 class，复杂值按策略降级）。
+- `video-module`、`image`、`plugin-float-image`：对齐、尺寸等优先走 class/data 输出。
+
+## 迁移建议
+
+1. 先在测试环境启用 `textStyleMode: 'class'` + `classStylePolicy: 'preserve-data'`。
+2. 观察 `onClassStyleUnsupported` 日志，补齐 `styleClassTokens` 与 CSS。
+3. 再按业务要求切到 `fallback-inline` 或 `strict`。

--- a/docs/zh/guide/editor-config.md
+++ b/docs/zh/guide/editor-config.md
@@ -57,6 +57,58 @@ editorConfig.scroll = false
 - 在线文档，如腾讯文档、语雀那样的，参考 [demo](https://wangeditor-next.github.io/demo/like-qq-doc.html) 中的“仿腾讯文档”
 :::
 
+## textStyleMode
+
+配置文本/段落样式导出模式。
+
+```ts
+editorConfig.textStyleMode = 'class' // 'inline' | 'class'
+```
+
+- `inline`（默认）：输出内联 `style`
+- `class`：输出 `class + data-w-e-*`，适合严格 CSP 场景
+
+详细使用与迁移建议见 [CSP class 样式模式](./csp-class-mode.md)。
+
+## classStylePolicy
+
+当 `textStyleMode = 'class'` 时，配置未注册 token 的处理策略。
+
+```ts
+editorConfig.classStylePolicy = 'preserve-data'
+// 'preserve-data' | 'fallback-inline' | 'strict'
+```
+
+- `preserve-data`（默认）：保留 `data-w-e-*`
+- `fallback-inline`：回退到 inline style
+- `strict`：直接抛错
+
+## styleClassTokens
+
+扩展 class 模式允许的 token 集合。
+
+```ts
+editorConfig.styleClassTokens = {
+    color: ['rgb(1, 2, 3)'],
+    fontSize: ['20px'],
+}
+```
+
+:::tip
+`styleClassTokens` 只注册 token，不自动注入业务 CSS。
+:::
+
+## onClassStyleUnsupported
+
+class 模式遇到未注册 token 时的通知回调。
+
+```ts
+editorConfig.onClassStyleUnsupported = payload => {
+    // payload: { type, value, scene, fallback, message }
+    console.warn(payload)
+}
+```
+
 ## maxLength onMaxLength
 
 配置编辑器的 maxlength ，参考 [demo](https://wangeditor-next.github.io/demo/max-length.html)。


### PR DESCRIPTION
## Summary
- add `csp-class-mode` guide pages in Chinese and English
- add sidebar entries for quick discovery
- document `textStyleMode`, `classStylePolicy`, `styleClassTokens`, and `onClassStyleUnsupported` in editor-config pages

## Validation
- pnpm docs:build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on CSP Class Style Mode for strict Content Security Policy environments that block inline styles.
  * Documented new editor configuration options: `textStyleMode`, `classStylePolicy`, `styleClassTokens`, and `onClassStyleUnsupported` callback for handling unsupported tokens.
  * Full documentation available in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->