### PR TITLE
ci(docs): sync navbar version with release dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,19 @@ on:
 
   # 允许你从 Actions 选项卡手动运行此工作流程
   workflow_dispatch:
+    inputs:
+      editor_version:
+        description: 'Optional editor version to render in navbar (e.g. 5.7.1)'
+        required: false
+        type: string
+
+  # 由主仓库 release workflow 触发，携带已发布版本号
+  repository_dispatch:
+    types: [editor-release-published]
+
+  # 兜底定时刷新，避免错过外部触发
+  schedule:
+    - cron: '25 2 * * *'
 
 # 设置 GITHUB_TOKEN 的权限，以允许部署到 GitHub Pages
 permissions:
@@ -45,8 +58,39 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install dependencies
         run: pnpm install # 或 pnpm install / yarn install / bun install
+      - name: Resolve editor version
+        id: editor_version
+        env:
+          INPUT_EDITOR_VERSION: ${{ inputs.editor_version }}
+          DISPATCH_EDITOR_VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+
+          version="${INPUT_EDITOR_VERSION:-}"
+          if [ -z "$version" ]; then
+            version="${DISPATCH_EDITOR_VERSION:-}"
+          fi
+          if [ -z "$version" ]; then
+            if version="$(pnpm view @wangeditor-next/editor version 2>/dev/null)"; then
+              echo "Resolved from npm: $version"
+            else
+              version="$(node -p "require('@wangeditor-next/editor/package.json').version")"
+              echo "::warning::Failed to fetch npm latest. Fallback to local installed version: $version"
+            fi
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Using editor version: $version"
       - name: Build with VitePress
+        env:
+          DOCS_EDITOR_VERSION: ${{ steps.editor_version.outputs.version }}
         run: pnpm docs:build # 或 pnpm docs:build / yarn docs:build / bun run docs:build
+      - name: Verify navbar version in build output
+        run: |
+          set -euo pipefail
+          version='${{ steps.editor_version.outputs.version }}'
+          grep -q "$version" docs/.vitepress/dist/index.html
+          grep -q "$version" docs/.vitepress/dist/en/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -3,6 +3,7 @@ import { defineConfig, type DefaultTheme } from 'vitepress';
 
 const require = createRequire(import.meta.url);
 const pkg = require('@wangeditor-next/editor/package.json');
+const editorVersion = process.env.DOCS_EDITOR_VERSION || pkg.version;
 
 export const en = defineConfig({
     lang: 'en-US',
@@ -64,7 +65,7 @@ function nav(): DefaultTheme.NavItem[] {
             link: 'https://wangeditor-next.github.io/demo/',
         },
         {
-            text: pkg.version,
+            text: editorVersion,
             items: [
                 {
                     text: 'Changelog',

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -3,6 +3,7 @@ import { defineConfig, type DefaultTheme } from 'vitepress';
 
 const require = createRequire(import.meta.url);
 const pkg = require('@wangeditor-next/editor/package.json');
+const editorVersion = process.env.DOCS_EDITOR_VERSION || pkg.version;
 
 export const zh = defineConfig({
     lang: 'zh-Hans',
@@ -64,7 +65,7 @@ function nav(): DefaultTheme.NavItem[] {
             link: 'https://wangeditor-next.github.io/demo/',
         },
         {
-            text: pkg.version,
+            text: editorVersion,
             items: [
                 {
                     text: '更新日志',


### PR DESCRIPTION
## Summary
- add `DOCS_EDITOR_VERSION` override for navbar version in both zh/en configs
- update deploy workflow to support workflow_dispatch input, repository_dispatch, and daily fallback
- resolve version from dispatch/input first, then npm latest, then local installed fallback
- add build-output assertion to ensure resolved version is rendered in zh/en navbar

## Validation
- local: `DOCS_EDITOR_VERSION=5.7.1 pnpm docs:build`
- actions run: https://github.com/wangeditor-next/docs/actions/runs/25995865475
  - build job passed (`Resolve editor version`, `Build with VitePress`, `Verify navbar version`)
  - deploy blocked by github-pages environment protection on non-main branch (expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment workflow now accepts manual editor version input for documentation builds
  * Documentation navbar editor version is now dynamically configurable across all language versions
  * Added automated verification to ensure the specified version appears in published documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangeditor-next/docs/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->